### PR TITLE
Task/voss 116 resource library functionality

### DIFF
--- a/docs/site/themes/template/assets/js/main.js
+++ b/docs/site/themes/template/assets/js/main.js
@@ -109,6 +109,39 @@ function showInitialUseCaseResources() {
     })
 }
 
+// loads additional resouces within resource lists when their associated "See More" buttons are clicked
+// set a "data-increment" value (Number) on the "See More" to load a specific amount
+// if no increment is set, all remaining resources will be shown
+function seeMoreOnClick() {
+    var seeMoreButtons = document.querySelectorAll('button.see-more');
+    seeMoreButtons.forEach(function(button) {
+        button.addEventListener('click', function() {
+            var associatedResources = button.previousElementSibling.querySelectorAll('li');
+            var increment = button.dataset.increment;
+            if (!increment) {
+                associatedResources.forEach(function(resource) {
+                    resource.classList.remove('d-none');
+                })
+                button.classList.add('d-none');
+            } else {
+                let i = button.dataset.visibleCount || 0;
+                while (increment) {
+                    if (associatedResources[i].classList.contains('d-none')) {
+                        associatedResources[i].classList.remove('d-none');
+                        increment--;
+                    }
+                    i++;
+                    if (i >= associatedResources.length) {
+                        button.classList.add('d-none');
+                        break;
+                    }
+                }
+                button.dataset.visibleCount = i;
+            }
+        })
+    })
+}
+
 function revealUseCaseResourcesOnClick() {
     var seeMoreButtons = document.querySelectorAll('button.see-more');
     seeMoreButtons.forEach(function(button) {
@@ -176,7 +209,7 @@ document.addEventListener('DOMContentLoaded', function(){
     createCopyButtons();
 
     showInitialUseCaseResources();
-    revealUseCaseResourcesOnClick();
+    seeMoreOnClick();
 
     // Load the medium-zoom library and attach based on css selector
     mediumZoom('.docs-content img')

--- a/docs/site/themes/template/assets/scss/_resources.scss
+++ b/docs/site/themes/template/assets/scss/_resources.scss
@@ -21,7 +21,7 @@
 }
 
 .accordion-wrapper {
-    padding-top: 0;
+    padding: 0;
     margin-top: 32px;
     .accordion {
         .panel {

--- a/docs/site/themes/template/layouts/_default/resources.html
+++ b/docs/site/themes/template/layouts/_default/resources.html
@@ -65,7 +65,7 @@
             <ul class="resource-list">
                 {{ partial "resources-all.html" . }}
             </ul>
-            <button class="see-more">View all resources</button>
+            <button class="see-more" data-increment="10">View more resources</button>
         </div>
         <div class="resources bg-lighter-blue">
             <div class="wrapper">

--- a/docs/site/themes/template/layouts/_default/resources.html
+++ b/docs/site/themes/template/layouts/_default/resources.html
@@ -65,7 +65,7 @@
             <ul class="resource-list">
                 {{ partial "resources-all.html" . }}
             </ul>
-            <p><button>View all resources</button></p>
+            <button class="see-more">View all resources</button>
         </div>
         <div class="resources bg-lighter-blue">
             <div class="wrapper">

--- a/docs/site/themes/template/layouts/partials/resources-all.html
+++ b/docs/site/themes/template/layouts/partials/resources-all.html
@@ -1,6 +1,6 @@
 {{ $data := sort .Site.Data.resources ".order" }}
 {{ range $index, $element := $data }}
-<li>
+<li class="d-none">
     <div>
         <div class="icon-container">
             <img src="/img/resources/icon-{{ .type }}.svg" alt="{{ .type }}" />


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
- Extend "see more" button JS:
  - reveal N more results if a `data-increment` attr is set
  - continue to reveal all if none set
- minor styling fix: padding below use case accordion

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: [VOSS-116](https://ampxd.atlassian.net/browse/VOSS-116) Resource Library Functionality

## Describe testing done for PR
<!--
Example: Created vSphere workload cluster to verify change.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
If including logic for buttons that "show all" and "show more" within the same function is too chunky, I'll gladly break this into two separate functions. There's some code reuse as-is, but I want to be sure it reads well too
